### PR TITLE
feat: add sold-out indicator to events with i18n and dark mode support

### DIFF
--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -19,6 +19,7 @@ const EVENTS_I18N = {
       'No te pierdas nuestras próximas citas. Te esperamos en eventos diseñados para inspirar, formar y conectar a la comunidad de mujeres en tecnología.',
     closed: 'Inscripciones cerradas',
     register: 'Registrarse',
+    soldOut: 'Agotado',
   },
   en: {
     upcoming: 'Upcoming Events',
@@ -26,6 +27,7 @@ const EVENTS_I18N = {
       "Don't miss our next gatherings. Join us at events designed to inspire, educate and connect women in tech.",
     closed: 'Registration closed',
     register: 'Register',
+    soldOut: 'Sold Out',
   },
 };
 import {
@@ -66,14 +68,21 @@ export default function Events({ events, locale = 'es' }) {
         {events.map((e, idx) => {
           // Determina si el evento es pasado usando util
           const isPast = e.date ? isPastEvent(e.date) : false;
+          const isSoldOut = e.soldOut === true;
+          const isDisabled = isPast || isSoldOut;
           return (
             <article
               key={`${e.title}-${idx}`}
-              className="relative bg-white rounded-3xl p-8 shadow-sm ring-1 ring-black/5 hover:shadow-md transition flex flex-col justify-between h-full"
+              className="relative bg-white dark:bg-gray-800 rounded-3xl p-8 shadow-sm ring-1 ring-black/5 dark:ring-white/10 hover:shadow-md transition flex flex-col justify-between h-full"
             >
               <div className="flex flex-col gap-2 flex-grow">
                 <div className="flex items-center justify-between min-h-[40px]">
-                  {e.status === 'Inscripciones Abiertas' && !isPast && (
+                  {isSoldOut && (
+                    <span className="inline-flex items-center px-4 py-1.5 rounded-full bg-amber-500 dark:bg-amber-600 text-white text-sm font-semibold shadow-sm">
+                      {i18n.soldOut}
+                    </span>
+                  )}
+                  {!isSoldOut && e.status === 'Inscripciones Abiertas' && !isPast && (
                     <span
                       className="inline-flex items-center px-4 py-1.5 rounded-full text-white text-sm font-semibold shadow-sm"
                       style={{ backgroundColor: 'var(--aw-color-secondary)' }}
@@ -81,21 +90,21 @@ export default function Events({ events, locale = 'es' }) {
                       {locale === 'en' ? 'Open Registrations' : e.status}
                     </span>
                   )}
-                  {isPast && (
-                    <span className="inline-flex items-center px-4 py-1.5 rounded-full bg-gray-400 text-white text-sm font-semibold shadow-sm">
+                  {!isSoldOut && isPast && (
+                    <span className="inline-flex items-center px-4 py-1.5 rounded-full bg-gray-400 dark:bg-gray-600 text-white text-sm font-semibold shadow-sm">
                       {i18n.closed}
                     </span>
                   )}
-                  {!isPast && <SocialShare url={e.url} title={e.title} />}
+                  {!isDisabled && <SocialShare url={e.url} title={e.title} />}
                 </div>
 
                 <h3
-                  className={`${isPast ? 'mt-2' : 'mt-5'} text-3xl md:text-4xl font-extrabold tracking-tight text-neutral-900`}
+                  className={`${isDisabled ? 'mt-2' : 'mt-5'} text-3xl md:text-4xl font-extrabold tracking-tight text-neutral-900 dark:text-white`}
                 >
                   {e.title}
                 </h3>
 
-                <ul className="mt-6 space-y-5 text-[1.125rem] text-slate-600">
+                <ul className="mt-6 space-y-5 text-[1.125rem] text-slate-600 dark:text-slate-300">
                   {e.date && (
                     <li className="flex items-center gap-3">
                       <svg
@@ -163,18 +172,30 @@ export default function Events({ events, locale = 'es' }) {
 
               <div className="mt-8 flex-shrink-0">
                 <div
-                  className={`p-1 rounded-full ring-2 ${isPast ? 'ring-gray-400/90' : 'ring-emerald-400/90'} min-h-[72px] flex items-center justify-center`}
+                  className={`p-1 rounded-full ring-2 ${isSoldOut ? 'ring-amber-400/90 dark:ring-amber-500/90' : isPast ? 'ring-gray-400/90 dark:ring-gray-600/90' : 'ring-emerald-400/90'} min-h-[72px] flex items-center justify-center`}
                 >
                   <a
-                    href={isPast ? undefined : e.url}
+                    href={isDisabled ? undefined : e.url}
                     target="_blank"
                     rel="noopener"
-                    className={`block w-full text-center rounded-full py-4 font-semibold transition ${isPast ? 'bg-gray-300 text-gray-500 cursor-not-allowed opacity-70' : 'text-white bg-gradient-to-r from-emerald-400 via-teal-400 to-sky-500 hover:opacity-95 active:opacity-90'}`}
-                    tabIndex={isPast ? -1 : 0}
-                    aria-disabled={isPast ? 'true' : 'false'}
-                    {...(isPast ? { onClick: (e) => e.preventDefault() } : {})}
+                    className={`block w-full text-center rounded-full py-4 font-semibold transition ${
+                      isSoldOut
+                        ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 cursor-not-allowed opacity-80'
+                        : isPast
+                          ? 'bg-gray-300 dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-not-allowed opacity-70'
+                          : 'text-white bg-gradient-to-r from-emerald-400 via-teal-400 to-sky-500 hover:opacity-95 active:opacity-90'
+                    }`}
+                    tabIndex={isDisabled ? -1 : 0}
+                    aria-disabled={isDisabled ? 'true' : 'false'}
+                    {...(isDisabled ? { onClick: (e) => e.preventDefault() } : {})}
                   >
-                    {isPast ? i18n.closed : locale === 'en' ? i18n.register : e.ctaLabel || i18n.register}
+                    {isSoldOut
+                      ? i18n.soldOut
+                      : isPast
+                        ? i18n.closed
+                        : locale === 'en'
+                          ? i18n.register
+                          : e.ctaLabel || i18n.register}
                   </a>
                 </div>
               </div>

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -11,6 +11,7 @@
   {
     "title": " Dos visiones de producto: Diseño y tecnología",
     "status": "Inscripciones Abiertas",
+    "soldOut": true,
     "date": "19 de Febrero 2026",
     "time": "18:30 - 21:00",
     "location": "The Bridge - Digital Talent Accelerator, 1 Plaza Pablo Ruiz Picasso, Madrid, 28020",

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -26,6 +26,7 @@ export const ui = {
       'No te pierdas nuestras próximas citas. Te esperamos en eventos diseñados para inspirar, formar y conectar a la comunidad de mujeres en tecnología.',
     'events.closed': 'Inscripciones cerradas',
     'events.register': 'Registrarse',
+    'events.soldOut': 'Agotado',
     // Language picker
     'lang.label': 'EN',
     'lang.switchTo': 'Switch to English',
@@ -50,6 +51,7 @@ export const ui = {
       "Don't miss our next gatherings. Join us at events designed to inspire, educate and connect women in tech.",
     'events.closed': 'Registration closed',
     'events.register': 'Register',
+    'events.soldOut': 'Sold Out',
     // Language picker
     'lang.label': 'ES',
     'lang.switchTo': 'Cambiar a Español',

--- a/src/pages/en/iwd.astro
+++ b/src/pages/en/iwd.astro
@@ -24,6 +24,8 @@ const celonisData = {
   description: 'Celonis is a global leader in process mining and execution management software.',
 };
 
+const iwdSoldOut = true;
+
 const iwdPartners = (await getCollection('partner'))
   .filter((p) => p.data.iwdPartner === true)
   .sort((a, b) => (a.data.order ?? 99) - (b.data.order ?? 99));
@@ -54,14 +56,31 @@ const iwdPartners = (await getCollection('partner'))
           technology.
         </p>
         <div class="mt-8">
-          <a
-            href="https://luma.com/ujpm8lye"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center justify-center rounded-lg border-2 border-black bg-primary dark:bg-[#165185] dark:border-none px-10 py-5 text-xl font-extrabold uppercase tracking-wide text-white shadow-[4px_4px_0_0_#000] transition hover:-translate-y-0.5 hover:shadow-[6px_6px_0_0_#000] focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-slate-900"
-          >
-            Register
-          </a>
+          {
+            iwdSoldOut ? (
+              <div class="flex flex-col items-start gap-3">
+                <span class="inline-flex items-center gap-2 rounded-full bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm dark:bg-amber-600">
+                  🎟️ Sold Out
+                </span>
+                <span
+                  class="inline-flex cursor-not-allowed items-center justify-center rounded-lg border-2 border-amber-500 bg-amber-100 px-10 py-5 text-xl font-extrabold uppercase tracking-wide text-amber-700 opacity-80 dark:border-amber-600 dark:bg-amber-900/30 dark:text-amber-300"
+                  aria-disabled="true"
+                  role="button"
+                >
+                  Register
+                </span>
+              </div>
+            ) : (
+              <a
+                href="https://luma.com/ujpm8lye"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center justify-center rounded-lg border-2 border-black bg-primary px-10 py-5 text-xl font-extrabold uppercase tracking-wide text-white shadow-[4px_4px_0_0_#000] transition hover:-translate-y-0.5 hover:shadow-[6px_6px_0_0_#000] focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-none dark:bg-[#165185] dark:focus:ring-offset-slate-900"
+              >
+                Register
+              </a>
+            )
+          }
         </div>
       </div>
     </Fragment>

--- a/src/pages/iwd.astro
+++ b/src/pages/iwd.astro
@@ -24,6 +24,8 @@ const celonisData = {
   description: 'Celonis is a global leader in process mining and execution management software.',
 };
 
+const iwdSoldOut = true;
+
 const iwdPartners = (await getCollection('partner'))
   .filter((p) => p.data.iwdPartner === true)
   .sort((a, b) => (a.data.order ?? 99) - (b.data.order ?? 99));
@@ -54,14 +56,31 @@ const iwdPartners = (await getCollection('partner'))
           las mujeres en tecnología.
         </p>
         <div class="mt-8">
-          <a
-            href="https://luma.com/ujpm8lye"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center justify-center rounded-lg border-2 border-black bg-primary dark:bg-[#165185] dark:border-none px-10 py-5 text-xl font-extrabold uppercase tracking-wide text-white shadow-[4px_4px_0_0_#000] transition hover:-translate-y-0.5 hover:shadow-[6px_6px_0_0_#000] focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-slate-900"
-          >
-            Me apunto
-          </a>
+          {
+            iwdSoldOut ? (
+              <div class="flex flex-col items-start gap-3">
+                <span class="inline-flex items-center gap-2 rounded-full bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm dark:bg-amber-600">
+                  🎟️ Agotado
+                </span>
+                <span
+                  class="inline-flex cursor-not-allowed items-center justify-center rounded-lg border-2 border-amber-500 bg-amber-100 px-10 py-5 text-xl font-extrabold uppercase tracking-wide text-amber-700 opacity-80 dark:border-amber-600 dark:bg-amber-900/30 dark:text-amber-300"
+                  aria-disabled="true"
+                  role="button"
+                >
+                  Me apunto
+                </span>
+              </div>
+            ) : (
+              <a
+                href="https://luma.com/ujpm8lye"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center justify-center rounded-lg border-2 border-black bg-primary px-10 py-5 text-xl font-extrabold uppercase tracking-wide text-white shadow-[4px_4px_0_0_#000] transition hover:-translate-y-0.5 hover:shadow-[6px_6px_0_0_#000] focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:border-none dark:bg-[#165185] dark:focus:ring-offset-slate-900"
+              >
+                Me apunto
+              </a>
+            )
+          }
         </div>
       </div>
     </Fragment>


### PR DESCRIPTION
- Add `soldOut` boolean field to events.json schema (marked on Feb 19 event)
- Add `events.soldOut` translation key to ui.ts (es: "Agotado", en: "Sold Out")
- Update Events.jsx: amber badge and disabled CTA for sold-out events,
  separate from the gray "closed" state for past events
- Add dark mode variants for card bg, text, badges and CTA button

https://claude.ai/code/session_01DawYy9Dp6AP5Wd7hb7f77g