### PR TITLE
feat(iwd): replace sold-out disabled button with waitlist CTA

### DIFF
--- a/src/pages/en/iwd.astro
+++ b/src/pages/en/iwd.astro
@@ -58,17 +58,21 @@ const iwdPartners = (await getCollection('partner'))
         <div class="mt-8">
           {
             iwdSoldOut ? (
-              <div class="flex flex-col items-start gap-3">
+              <div class="flex flex-col items-start gap-4">
                 <span class="inline-flex items-center gap-2 rounded-full bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm dark:bg-amber-600">
                   🎟️ Sold Out
                 </span>
-                <span
-                  class="inline-flex cursor-not-allowed items-center justify-center rounded-lg border-2 border-amber-500 bg-amber-100 px-10 py-5 text-xl font-extrabold uppercase tracking-wide text-amber-700 opacity-80 dark:border-amber-600 dark:bg-amber-900/30 dark:text-amber-300"
-                  aria-disabled="true"
-                  role="button"
+                <p class="text-base text-gray-700 dark:text-gray-300 max-w-sm">
+                  Tickets are sold out. Join the waitlist and we'll notify you if a spot becomes available.
+                </p>
+                <a
+                  href="https://luma.com/ujpm8lye"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center justify-center rounded-lg border-2 border-amber-500 bg-amber-100 px-10 py-5 text-xl font-extrabold uppercase tracking-wide text-amber-700 shadow-[4px_4px_0_0_theme(colors.amber.500)] transition hover:-translate-y-0.5 hover:shadow-[6px_6px_0_0_theme(colors.amber.500)] focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:border-amber-500 dark:bg-amber-900/30 dark:text-amber-300 dark:shadow-[4px_4px_0_0_theme(colors.amber.600)] dark:hover:shadow-[6px_6px_0_0_theme(colors.amber.600)] dark:focus:ring-offset-slate-900"
                 >
-                  Register
-                </span>
+                  Join the waitlist
+                </a>
               </div>
             ) : (
               <a

--- a/src/pages/iwd.astro
+++ b/src/pages/iwd.astro
@@ -58,17 +58,21 @@ const iwdPartners = (await getCollection('partner'))
         <div class="mt-8">
           {
             iwdSoldOut ? (
-              <div class="flex flex-col items-start gap-3">
+              <div class="flex flex-col items-start gap-4">
                 <span class="inline-flex items-center gap-2 rounded-full bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm dark:bg-amber-600">
-                  🎟️ Agotado
+                  🎟️ Entradas agotadas
                 </span>
-                <span
-                  class="inline-flex cursor-not-allowed items-center justify-center rounded-lg border-2 border-amber-500 bg-amber-100 px-10 py-5 text-xl font-extrabold uppercase tracking-wide text-amber-700 opacity-80 dark:border-amber-600 dark:bg-amber-900/30 dark:text-amber-300"
-                  aria-disabled="true"
-                  role="button"
+                <p class="text-base text-gray-700 dark:text-gray-300 max-w-sm">
+                  Las entradas se han agotado. Apúntate a la lista de espera y te avisaremos si se libera alguna plaza.
+                </p>
+                <a
+                  href="https://luma.com/ujpm8lye"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center justify-center rounded-lg border-2 border-amber-500 bg-amber-100 px-10 py-5 text-xl font-extrabold uppercase tracking-wide text-amber-700 shadow-[4px_4px_0_0_theme(colors.amber.500)] transition hover:-translate-y-0.5 hover:shadow-[6px_6px_0_0_theme(colors.amber.500)] focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:border-amber-500 dark:bg-amber-900/30 dark:text-amber-300 dark:shadow-[4px_4px_0_0_theme(colors.amber.600)] dark:hover:shadow-[6px_6px_0_0_theme(colors.amber.600)] dark:focus:ring-offset-slate-900"
                 >
-                  Me apunto
-                </span>
+                  Apuntarse a lista de espera
+                </a>
               </div>
             ) : (
               <a


### PR DESCRIPTION
When iwdSoldOut is true, the hero now shows:
- Amber "Entradas agotadas" / "Sold Out" badge
- Explanatory message about joining the waitlist
- Active amber button "Apuntarse a lista de espera" / "Join the waitlist" linking to luma.com, matching the IWD retro-shadow button style

https://claude.ai/code/session_01DawYy9Dp6AP5Wd7hb7f77g